### PR TITLE
Add missing imports

### DIFF
--- a/parsec/commands/jobs/search_jobs.py
+++ b/parsec/commands/jobs/search_jobs.py
@@ -1,5 +1,5 @@
 import click
-from parsec.cli import pass_context
+from parsec.cli import pass_context, json_loads
 from parsec.decorators import custom_exception, dict_output
 
 
@@ -13,6 +13,6 @@ def cli(ctx, job_info):
 
 Output:
 
-    
+
     """
     return ctx.gi.jobs.search_jobs(json_loads(job_info))

--- a/parsec/commands/tools/run_tool.py
+++ b/parsec/commands/tools/run_tool.py
@@ -1,5 +1,5 @@
 import click
-from parsec.cli import pass_context
+from parsec.cli import pass_context, json_loads
 from parsec.decorators import custom_exception, dict_output
 
 
@@ -15,6 +15,6 @@ def cli(ctx, history_id, tool_id, tool_inputs):
 
 Output:
 
-    
+
     """
     return ctx.gi.tools.run_tool(history_id, tool_id, json_loads(tool_inputs))


### PR DESCRIPTION
A little fix for an exception raised when calling run_tool for example:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/parsec/decorators.py", line 13, in custom_exception
    return wrapped(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/parsec/decorators.py", line 37, in dict_output
    output = wrapped(*args, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/parsec/commands/tools/run_tool.py", line 20, in cli
    return ctx.gi.tools.run_tool(history_id, tool_id, json_loads(tool_inputs))
NameError: global name 'json_loads' is not defined
```

Seen in https://travis-ci.org/bgruening/docker-galaxy-stable/jobs/467400897
It would be cool to push a new release on pypi to fix it for https://github.com/bgruening/docker-galaxy-stable/pull/464 (though there are a few other errors there)