### PR TITLE
Remove wait_for_completion in download_datasets from the bioblend call.

### DIFF
--- a/parsec/commands/datasets/download_dataset.py
+++ b/parsec/commands/datasets/download_dataset.py
@@ -20,7 +20,7 @@ from parsec.decorators import custom_exception, dict_output
 @click.option(
     "--wait_for_completion",
     help="This parameter is deprecated and ignored, it will be removed in BioBlend 0.12.",
-    default="True",
+    default="False",
     show_default=True,
     is_flag=True
 )
@@ -42,4 +42,4 @@ Output:
     If a file_path argument is not provided, returns a dict containing the file_content.
                  Otherwise returns nothing.
     """
-    return ctx.gi.datasets.download_dataset(dataset_id, file_path=file_path, use_default_filename=use_default_filename, wait_for_completion=wait_for_completion, maxwait=maxwait)
+    return ctx.gi.datasets.download_dataset(dataset_id, file_path=file_path, use_default_filename=use_default_filename, maxwait=maxwait)


### PR DESCRIPTION
This fixes error from current bioblend dependency, where this argument has been removed. The argument is still accepted by the parsec script for compatibility, but it is ignored.
This was tested in this [tutorial](https://github.com/andreyto/galaxy_r_api_workshop).
