### PR TITLE
Use Toolshed interface to search toolshed

### DIFF
--- a/parsec/commands/toolshed_tools/search_tools.py
+++ b/parsec/commands/toolshed_tools/search_tools.py
@@ -49,4 +49,4 @@ Output:
              'page_size': '2',
              'total_results': '118'}
     """
-    return ctx.gi.tools.search_tools(q, page=page, page_size=page_size)
+    return ctx.ti.tools.search_tools(q, page=page, page_size=page_size)


### PR DESCRIPTION
`search_tools` is a method of the Toolshed client, not the Galaxy one, so `ti` should be used, not `gi`.